### PR TITLE
broken theme view fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ to the developers.
 
 # Changelog
 
+* 2010-10-25
+	* Enforcing default theme "light" when no or broken theme is set
+
 * 2010-10-23
 	* Added Wikio Score test that records the score from wikio.de for a
 	specific id

--- a/app/lib/Franklin.php
+++ b/app/lib/Franklin.php
@@ -35,6 +35,8 @@ class Franklin extends Object
 	
 	const APPVERSION = '0.21';
 	
+	const DEFAULTTHEME = 'light';
+	
 	public static $CLIMODE = false;
 	
 	public static $debug = DEBUG_VERBOSE;
@@ -87,9 +89,12 @@ class Franklin extends Object
 			if (file_exists($themeFile)) {
 				$this->themeFilename = $themeFile;
 			} else {
-
+				$this->themeFilename = dirname(__FILE__).'/../theme/'.self::DEFAULTTHEME.'.php';
 			}
+		} else {
+				$this->themeFilename = dirname(__FILE__).'/../theme/'.self::DEFAULTTHEME.'.php';
 		}
+		
 		foreach($config['groups'] as $groupConfig) {
 			$TestGroup = new TestGroup($groupConfig['name'], $groupConfig['host']);
 			// add tests to group


### PR DESCRIPTION
After updating to the recent 0.21 of franklin I got a blank page (error: file "light" couldn't be loaded) due to a uncomplete error handling when no or a false theme is set.
